### PR TITLE
Fixes puppet-ssl for Debian/Ubuntu

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,11 @@ class ssl::params {
       $crt_dir = '/etc/pki/tls/certs'
       $key_dir = '/etc/pki/tls/private'
     }
+    'Debian': {
+      $package = 'openssl'
+      $crt_dir = '/etc/ssl/certs'
+      $key_dir = '/etc/ssl/private'
+    }
     default: {
       fail("\$::osfamily = '${::osfamily}' not supported!")
     }


### PR DESCRIPTION
This change allows the module to work on Debian and Debian based OSes.
