### PR TITLE
added archlinux support,

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 pkg/*
 .DS_Store
+/.project
+/metadata.json

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,11 @@ class ssl::params {
       $crt_dir = '/etc/ssl/certs'
       $key_dir = '/etc/ssl/private'
     }
+    'Archlinux': {
+      $package = 'openssl'
+      $crt_dir = '/etc/ssl/certs'
+      $key_dir = '/etc/ssl/private'
+    }
     default: {
       fail("\$::osfamily = '${::osfamily}' not supported!")
     }


### PR DESCRIPTION
Had two choices both are possible on archlinux:
/etc/pki/tls and /etc/ssl/certs, I looked at the package ca-certificates these
were installed in /etc/ssl/certs, so that's where they go.
